### PR TITLE
Add support for exporting bitwarden card, identity and secure notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Performs the following conversions on the BitWarden Vault,
 
 ### Drawbacks
 
-BitWarden supports many URLs for an entry while [PyKeePass](https://github.com/libkeepass/pykeepass#adding-entries) only supports a single URL. The script only copies the first URL into the KeePass database. 
+BitWarden supports many URLs for an entry while [PyKeePass](https://github.com/libkeepass/pykeepass#adding-entries) only supports a single URL. The script only copies the first URL into the KeePass database. The rest are copied into the 'notes' field. Likewise, for any Bitwarden 'card' or 'identity' type entries, the fields (with labels) will be imported into the 'notes' field.
 
 [PyKeePass](https://github.com/libkeepass/pykeepass/blob/master/pykeepass/pykeepass.py#L612) requires entries to have a unique title and username combination. The script adds a suffix to the title (e.g, 'name (1)', 'name (2)') in case of a collision.
 

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -137,7 +137,7 @@ def convert(input_file, output):
 
         title = x['name']
 
-        seen_key = ''.join((group_id, title, username))
+        seen_key = ''.join((group_id or "", title, username if username is not None else ""))
         seen_entries[seen_key] += 1
 
         if seen_entries[seen_key] > 1:

--- a/lib/__init__.py
+++ b/lib/__init__.py
@@ -86,6 +86,92 @@ def create_keepass_groups(kp, folders_list):
     return groups_dict
 
 
+def _login(item):
+    """Handle login entries
+
+        Returns: title, username, password, url, notes (include any extra URLs)
+
+    """
+    title = item['name']
+    notes = item.get('notes', '') or ''
+    url = None
+
+    if len(item['login'].get('uris', [])) > 0:
+        urls = [i['uri'] or '' for i in item['login']['uris']]
+        url = urls[0]
+        if len(urls) > 1:
+            notes = "{}\n{}".format(notes, "\n".join(urls[1:]))
+
+    username = item['login'].get('username', '') or ''
+    password = item['login'].get('password', '') or ''
+
+    return title, username, password, url, notes
+
+
+def _card(item):
+    """Handle card entries
+
+        Returns: title (append " - Card" to the name,
+                 username (Card brand),
+                 password (card number),
+                 url (none),
+                 notes (including all card info)
+
+    """
+    notes = item.get('notes', "") or ""
+    # Add card info to the notes
+    notes = notes + ("\n".join([f"{i}: {j}" for i, j in item.get('card', "").items()]))
+    return f"{item['name']} - Card", \
+           item.get('card', {}).get('brand', '') or "", \
+           item.get('card', {}).get('number', "") or "", \
+           "", \
+           notes
+
+
+def _identity(item):
+    """Handle identity entries
+
+        Returns: title, username, password, url, notes
+
+    """
+    notes = item.get('notes', "") or ""
+    # Add identity info to the notes
+    notes = notes + ("\n".join([f"{i}: {j}" for i, j in item.get('identity', "").items()]))
+    return f"{item['name']} - Identity", "", "", "", notes
+
+
+def _note(item):
+    """Handle secure note entries
+
+        Returns: title, username, password, url, notes
+
+    """
+    return f"{item['name']} - Secure Note", "", "", "", item.get('notes', '') or ""
+
+
+def _input_file(filename):
+    """Open input file if given
+
+        Args: filename - string
+        Returns: vault - dict
+
+    """
+    if not filename:
+        return None
+    with codecs.open(filename, 'r', 'utf-8') as fname:
+        input_str = fname.read()
+
+    try:
+        vault = json.loads(input_str)
+        if vault['encrypted'] is True:
+            print("Unsupported: exported json file is encrypted")
+            sys.exit(-1)
+    except json.decoder.JSONDecodeError as err:
+        print(err)
+        sys.exit(-1)
+    return vault
+
+
 def convert(input_file, output):
     if 'BITWARDEN_PASS' in os.environ:
         password = os.environ['BITWARDEN_PASS']
@@ -93,49 +179,25 @@ def convert(input_file, output):
         password = getpass.getpass('Master Password: ')
     print('')
 
-    kp = pykeepass.create_database(output, password=password)
+    kpo = pykeepass.create_database(output, password=password)
 
-    vault = None
-    if input_file is not None:
-        input_str = ""
-        with codecs.open(input_file, 'r', 'utf-8') as f:
-            input_str = f.read()
-
-        try:
-            vault = json.loads(input_str)
-            if vault['encrypted'] is True:
-                print("Unsupported: exported json file is encrypted")
-                sys.exit(-1)
-        except json.decoder.JSONDecodeError:
-            sys.exit(-1)
-
+    vault = _input_file(input_file) or None
     folders_list = fetch_bitwarden_folders(vault, password)
-    groups = create_keepass_groups(kp, folders_list)
+    groups = create_keepass_groups(kpo, folders_list)
 
     items_list = fetch_bitwarden_items(vault, password)
     print('')
 
     seen_entries = Counter({})
-    for x in items_list:
+    types = {1: _login, 2: _note, 3: _card, 4: _identity}
+    for item in items_list:
         group_id = 'root'
-        dest_group = kp.root_group
-        if x['folderId'] in groups:
-            group_id = x['folderId']
+        dest_group = kpo.root_group
+        if item['folderId'] in groups:
+            group_id = item['folderId']
             dest_group = groups[group_id]
 
-        url = None
-        if 'uris' in x['login'] and len(x['login']['uris']) > 0:
-            url = x['login']['uris'][0]['uri']
-
-        username = x['login']['username']
-        if username is None:
-            username = ''
-
-        password = x['login']['password']
-        if password is None:
-            password = ''
-
-        title = x['name']
+        title, username, password, url, notes = types[item['type']](item)
 
         seen_key = ''.join((group_id or "", title, username if username is not None else ""))
         seen_entries[seen_key] += 1
@@ -143,11 +205,10 @@ def convert(input_file, output):
         if seen_entries[seen_key] > 1:
             title = ''.join((title, ' (', str(seen_entries[seen_key] - 1), ')'))
 
-        kp.add_entry(
+        kpo.add_entry(
             dest_group,
             title, username, password,
-            url=url, notes=x['notes']
+            url=url, notes=notes
         )
 
-    kp.save()
-
+    kpo.save()


### PR DESCRIPTION
Fixes one bug and as the title says, also will import secure notes, cards and
identities.

- adds a '- Card', '- Identity', '- Secure Note' to the title
- adds any extra URLs to notes for the login type
- adds card or identity info to the notes
