### PR TITLE
Fixed TOTP not being exported to KP if BW stores only secret instead of full URI

### DIFF
--- a/bitwarden_to_keepass/convert.py
+++ b/bitwarden_to_keepass/convert.py
@@ -243,7 +243,16 @@ class KeePassConvert:
             if seen_entries[seen_key] > 1:
                 title = "".join((title, " (", str(seen_entries[seen_key] - 1), ")"))
 
-            self.kp_db.add_entry(dest_group, title, username, password, url=url, notes=notes, otp=totp)
+            otp_value = None
+            if len(totp) > 0:
+                if totp.startswith("otpauth://"):
+                    otp_value = totp
+                else:
+                    otp_value = f"otpauth://totp/{title}:{username}?secret={totp}"
+
+            self.kp_db.add_entry(
+                dest_group, title, username, password, url=url, notes=notes, otp=otp_value
+            )
 
     def save(self):
         """Save the KeePass database"""


### PR DESCRIPTION
Fixed issue with TOTP not being exported to KP when BW stores only secret instead of full URI
